### PR TITLE
Add support for pull_request_target event

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub action that will comment on the relevant open PR with a file contents w
 
 - Requires the `GITHUB_TOKEN` secret.
 - Requires the comment's artifact in the `msg` parameter.
-- Supports `push` and `pull_request` event types.
+- Supports `push`, `pull_request` and `pull_request_target` event types.
 
 ### Sample workflow
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ end
 
 repo = event["repository"]["full_name"]
 
-if ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+if ["pull_request", "pull_request_target"].include? ENV.fetch("GITHUB_EVENT_NAME")
   pr_number = event["number"]
 else
   pulls = github.pull_requests(repo, state: "open")


### PR DESCRIPTION
Please review.

Resolves #6 

Project maintainers also may want to add a version tag when the PR is merged.

Suggested version is 1.1, as this change is not a breaking change and ensures backward compatibility. 